### PR TITLE
feat(MockSTDIN): add reset() method to allow pushing data post-EOF

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ feels like those are needed. Patches welcome.
   - [send()](#mockstdinsend)
   - [end()](#mockstdinend)
   - [restore()](#mockstdinrestore)
+  - [reset()](#mockstdinreset)
 
 ---
 
@@ -76,6 +77,26 @@ stdin.end();
 ```
 
 Alias for [MockSTDIN#send(null)](#mockstdinsend). Results in dispatching an `end` event.
+
+**return value**: The `MockSTDIN` instance, for chaining.
+
+---
+
+######MockSTDIN#reset()
+
+**example**
+
+```js
+var stdin = require('mock-stdin').stdin();
+stdin.end();
+stdin.reset();
+stdin.send("some data");
+```
+
+Ordinarily, a Readable stream will throw when attempting to push after an EOF. This routine will
+reset the `ended` state of a Readable stream, preventing it from throwing post-EOF. This prevents
+being required to re-create a mock STDIN instance during certain tests where a fresh stdin is
+required.
 
 **return value**: The `MockSTDIN` instance, for chaining.
 

--- a/lib/mock/stdin.js
+++ b/lib/mock/stdin.js
@@ -93,6 +93,12 @@ MockSTDIN.prototype.restore = function MockSTDINRestore() {
   return this;
 };
 
+MockSTDIN.prototype.reset = function MockSTDINReset() {
+  var state = this._readableState;
+  state.ended = false;
+  return this;
+};
+
 MockSTDIN.prototype._read = function MockSTDINRead(size) {
   if (size === void 0) size = 256;
   var count = 0;

--- a/test/stdin.spec.js
+++ b/test/stdin.spec.js
@@ -200,5 +200,23 @@ module.exports.stdin = {
       test.ok(called, "'end' event was not received.");
       test.done();
     });
+  },
+
+
+  "MockSTDIN#reset()": function (test) {
+    var received = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on("data", function(data) {
+      received += data;
+    });
+    process.stdin.end();
+    process.stdin.reset();
+
+    test.doesNotThrow(function() {
+      process.stdin.send("Please don't throw, little lamb!");
+    }, "should not throw when sending data after end when reset() called");
+
+    test.equal(received, "Please don't throw, little lamb!");
+    test.done();
   }
 };


### PR DESCRIPTION
Ordinarily, a Readable stream will throw when attempting to push after an EOF.
This routine will reset the `ended` state of a Readable stream, preventing it
from throwing post-EOF. This prevents being required to re-create a mock STDIN
instance during certain tests where a fresh stdin is required.

Closes #2
