### PR TITLE
feat(MockSTDIN): allow encoding to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ registered.
 
 ---
 
-######MockSTDIN#send(data)
+######MockSTDIN#send(data, encoding)
 
 **example**
 
 ```js
 var stdin = require('mock-stdin').stdin();
-stdin.send("Some text");
+stdin.send("Some text", "ascii");
 stdin.send(Buffer("Some text", "Some optional encoding"));
 stdin.send([
   "Array of lines",
@@ -62,6 +62,9 @@ dispatched.
 **parameters**
   - `data`: A `String`, `Buffer`, `Array<String>`, or `null`. The `data` parameter will result in
     the default encoding if specified as a string or array of strings.
+  - `encoding`: An optional encoding which is used when `data` is a `String`.
+      Node.js's internal Readable Stream will convert the specified encoding into the output
+      encoding, which is transcoded if necessary.
 
 **return value**: The `MockSTDIN` instance, for chaining.
 

--- a/lib/mock/stdin.js
+++ b/lib/mock/stdin.js
@@ -40,7 +40,7 @@ function MockSTDIN(restoreTarget) {
 
 inherits(MockSTDIN, stream.Readable);
 
-function MockData(chunk) {
+function MockData(chunk, encoding) {
   Object.defineProperties(this, {
     data: {
       value: chunk,
@@ -69,6 +69,12 @@ function MockData(chunk) {
     done: {
       writable: true,
       value: false,
+      configurable: false,
+      enumerable: false
+    },
+    encoding: {
+      writable: false,
+      value: ((typeof encoding === "string") && encoding) || null,
       configurable: false,
       enumerable: false
     }
@@ -100,10 +106,16 @@ MockSTDIN.prototype.emit = function MockSTDINEmit(name) {
   return Readable$emit.apply(this, arguments);
 };
 
-MockSTDIN.prototype.send = function MockSTDINWrite(text) {
-  if (Array.isArray(text)) text = text.join('\n');
+MockSTDIN.prototype.send = function MockSTDINWrite(text, encoding) {
+  if (Array.isArray(text)) {
+    if (arguments.length > 1) {
+      throw new TypeError("Cannot invoke MockSTDIN#send(): `encoding` " +
+                          "specified while text specified as an array.");
+    }
+    text = text.join('\n');
+  }
   if (Buffer.isBuffer(text) || typeof text === 'string' || text === null) {
-    var data = new MockData(text);
+    var data = new MockData(text, encoding);
     this._mockData.push(data);
     this._read();
     if (!this._flags.emittedData && this._readableState.length) {
@@ -149,9 +161,11 @@ MockSTDIN.prototype._read = function MockSTDINRead(size) {
     var item = this._mockData[0];
     var leftInChunk = item.length - item.pos;
     var remaining = size === Infinity ? leftInChunk : size - count;
+    var encoding = item.encoding;
     var toProcess = Math.min(leftInChunk, remaining);
+    var chunk = this._flags.lastChunk = item.chunk(toProcess);
 
-    if (!this.push(this._flags.lastChunk = item.chunk(toProcess))) {
+    if (!(encoding === null ? this.push(chunk) : this.push(chunk, encoding))) {
       read = false;
     }
 

--- a/test/stdin.spec.js
+++ b/test/stdin.spec.js
@@ -169,6 +169,50 @@ module.exports.stdin = {
     test.done();
   },
 
+  "MockSTDIN#send(<Array>, <Encoding>)": function (test) {
+    var endCalled = false;
+    var data = '';
+    var errors = [];
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("error", function(error) {
+      errors.push(error);
+    });
+    process.stdin.on("end", function() {
+      endCalled = true;
+    });
+    process.stdin.on("data", function(text) {
+      data += text;
+    });
+    process.stdin.resume();
+    test.throws(function() {
+      process.stdin.send(["44GT44KT44Gr44Gh44Gv", "5LiW55WM"], "base64");
+    }, TypeError, "should have thrown.");
+    test.done();
+  },
+
+
+  "MockSTDIN#send(<String>, <Encoding>)": function (test) {
+    var endCalled = false;
+    var data = '';
+    var errors = [];
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("error", function(error) {
+      errors.push(error);
+    });
+    process.stdin.on("end", function() {
+      endCalled = true;
+    });
+    process.stdin.on("data", function(text) {
+      data += text;
+    });
+    process.stdin.resume();
+    process.stdin.send("44GT44KT44Gr44Gh44Gv5LiW55WM", "base64");
+    test.equals(data, "こんにちは世界", "'data' should be decoded from base64.");
+    test.deepEqual(errors, [], "'error' event should not be received.");
+    test.ok(!endCalled, "'end' event should not be received.");
+    test.done();
+  },
+
 
   "MockSTDIN#end()": function (test) {
     var called = false;


### PR DESCRIPTION
This isn't as useful as I thought it would be, but woo features.

Closes #6
