### PR TITLE
Support set raw mode

### DIFF
--- a/lib/mock/stdin.js
+++ b/lib/mock/stdin.js
@@ -177,6 +177,11 @@ MockSTDIN.prototype._read = function MockSTDINRead(size) {
   }
 };
 
+MockSTDIN.prototype.setRawMode = function MockSTDINSetRawMode (bool) {
+  if (typeof bool !== 'boolean') throw new TypeError('setRawMode only takes booleans');
+  return;
+};
+
 function endReadable(stream) {
   // Synchronously emit an end event, if possible.
   var state = stream._readableState;

--- a/lib/mock/stdin.js
+++ b/lib/mock/stdin.js
@@ -179,7 +179,7 @@ MockSTDIN.prototype._read = function MockSTDINRead(size) {
 
 MockSTDIN.prototype.setRawMode = function MockSTDINSetRawMode (bool) {
   if (typeof bool !== 'boolean') throw new TypeError('setRawMode only takes booleans');
-  return;
+  return this;
 };
 
 function endReadable(stream) {

--- a/test/stdin.spec.js
+++ b/test/stdin.spec.js
@@ -289,5 +289,26 @@ module.exports.stdin = {
 
     test.equal(received, "Please don't throw, little lamb!");
     test.done();
+  },
+
+
+  "MockSTDIN#setRawMode(<String>)": function (test) {
+    function thrower () {
+      process.stdin.setRawMode('');
+    }
+    test.throws(thrower, TypeError);
+    test.done();
+  },
+
+
+  "MockSTDIN#SetRawMode(<Boolean>)": function (test) {
+    function notthrower () {
+      process.stdin.setRawMode(true);
+      process.stdin.setRawMode(false);
+      process.stdin.end();
+    }
+
+    test.doesNotThrow(notthrower);
+    test.done();
   }
 };


### PR DESCRIPTION
After looking over the TTY documentation I realized setRawMode only takes booleans.

This basically throws if it is not a boolean, otherwise `return this`.